### PR TITLE
Change to SHA-1 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ In today's crazy world of the Internet, untrusted environments are everywhere. H
 the wild? Sign it! Given a key that you know (and others don't), you can cryptographically sign your data and send it
 into the wild. When you get the data back, you can easily check that the data wasn't changed.
 
-Internally, dangerous uses HMAC and SHA265 for signing by default. 
+Internally, dangerous uses HMAC and SHA1 for signing by default.
 
 
 ## Installation

--- a/generic.go
+++ b/generic.go
@@ -2,7 +2,7 @@ package dangerous
 
 import (
 	"crypto/hmac"
-	"crypto/sha256"
+	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -15,7 +15,7 @@ type Signer interface {
 }
 
 // GenericSigner is the first and simple signer that is sufficient for simple applications. This signer
-// takes a key of sufficient length. It will generate the signature based on HMAC+SHA256.
+// takes a key of sufficient length. It will generate the signature based on HMAC+SHA1.
 type GenericSigner struct {
 	key []byte
 }
@@ -34,12 +34,12 @@ func (gs *GenericSigner) b64Decode(message string) ([]byte, error) {
 }
 
 func (gs *GenericSigner) computeSignature(message string) []byte {
-	h := hmac.New(sha256.New, gs.key)
+	h := hmac.New(sha1.New, gs.key)
 	h.Write([]byte(message))
 	return h.Sum(nil)
 }
 
-// Sign will compute the HMAC-SHA256 signature of the given message. The message and signature are then individually
+// Sign will compute the HMAC-SHA1 signature of the given message. The message and signature are then individually
 // base64 encoded and concatenated by a period.
 func (gs *GenericSigner) Sign(message string) string {
 	signature := gs.computeSignature(message)

--- a/generic_test.go
+++ b/generic_test.go
@@ -22,7 +22,7 @@ func TestNewGenericSigner(t *testing.T) {
 func TestGenericSigner_Sign(t *testing.T) {
 	key := "testing"
 	message := "hello"
-	signedMessage := "aGVsbG8=.+JOUrYi7eQZbEMBgqnN8bCkdk5B7zuq5hqZ933+dsak="
+	signedMessage := "aGVsbG8=.8jTp+A58ZOwEIoPSkPQc/eUPf6k="
 
 	signer := &GenericSigner{key: []byte(key)}
 
@@ -36,7 +36,7 @@ func TestGenericSigner_Sign(t *testing.T) {
 func TestGenericSigner_Verify(t *testing.T) {
 	key := "testing"
 	message := "hello"
-	signedMessage := "aGVsbG8=.+JOUrYi7eQZbEMBgqnN8bCkdk5B7zuq5hqZ933+dsak="
+	signedMessage := "aGVsbG8=.8jTp+A58ZOwEIoPSkPQc/eUPf6k="
 
 	signer := &GenericSigner{key: []byte(key)}
 


### PR DESCRIPTION
In general, it's apparently more normal to use SHA-1 as a default. So we
shall do the same. Support for additional hash functions will be added
in the future.